### PR TITLE
Make configuration reading synchronous

### DIFF
--- a/src/config_test.rs
+++ b/src/config_test.rs
@@ -13,7 +13,7 @@ async fn invalid_uri_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config).await;
+    let load_result = MAuthInfo::from_config_section(bad_config);
     assert!(matches!(load_result, Err(ConfigReadError::InvalidUri(_))));
 }
 
@@ -27,7 +27,7 @@ async fn bad_file_path_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config).await;
+    let load_result = MAuthInfo::from_config_section(bad_config);
     assert!(matches!(
         load_result,
         Err(ConfigReadError::FileReadError(_))
@@ -46,7 +46,7 @@ async fn bad_key_file_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config).await;
+    let load_result = MAuthInfo::from_config_section(bad_config);
     fs::remove_file(&filename).await.unwrap();
     assert!(matches!(load_result, Err(ConfigReadError::OpenSSLError(_))));
 }
@@ -66,7 +66,7 @@ async fn bad_uuid_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config).await;
+    let load_result = MAuthInfo::from_config_section(bad_config);
     fs::remove_file(&filename).await.unwrap();
     assert!(matches!(
         load_result,

--- a/src/protocol_test_suite.rs
+++ b/src/protocol_test_suite.rs
@@ -38,7 +38,6 @@ async fn setup_mauth_info() -> (MAuthInfo, u64) {
     };
     (
         MAuthInfo::from_config_section(mock_config_section)
-            .await
             .unwrap(),
         sign_config.request_time,
     )


### PR DESCRIPTION
There are 3 reasons for this:
- I am using [another library](https://github.com/tag1consulting/goose) which creates its own async reactor internally. It is more natural to first deal with setup and configuration and then call that library than somehow setup things within the context of the library. 
But not two reactors can run at the same time so if reading the config is async, I need to setup a reactor, read the file, teardown the reactor which is a lot of work and boilerplate for just reading a file.

- Other than my very specific use-case above, I think it is ok to block reading a small config file. This will happen at startup so really who cares about making this async, I'd say.

- Worse case someone really wishes this to be async, I think you can always make an async function out of a non-async function by just making a function marked as async and call the non-async ?

@masongup-mdsol

