### PR TITLE
Fix V1 signatures

### DIFF
--- a/src/protocol_test_suite.rs
+++ b/src/protocol_test_suite.rs
@@ -38,8 +38,7 @@ async fn setup_mauth_info() -> (MAuthInfo, u64) {
         v2_only_authenticate: None,
     };
     (
-        MAuthInfo::from_config_section(mock_config_section)
-            .unwrap(),
+        MAuthInfo::from_config_section(mock_config_section).unwrap(),
         sign_config.request_time,
     )
 }
@@ -63,7 +62,7 @@ async fn test_string_to_sign(file_name: String) {
             body_file_path.push(&file_name);
             body_file_path.push(filename_str);
             fs::read(body_file_path).await.unwrap()
-        },
+        }
         _ => vec![],
     };
 


### PR DESCRIPTION
It seems the V1 signatures got broken somewhere along the way. Turns out I had an extra line break in the signature string, and the hash output is supposed to be hex encoded before being signed. Requests signed with V1 seem to work correctly now.