### PR TITLE
Fix Validation of v1 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ let mut req = Request::new(body);
 mauth_info.sign_request(&mut req, &body_digest);
 match client.request(req).await {
     Err(err) => println!("Got error {}", err),
-    Ok(response) => match mauth_info.validate_response(response).await {
-        Ok(resp_body) => println!("Got validated response body {}", &resp_body),
+    Ok(mut response) => match mauth_info.validate_response(&mut response).await {
+        Ok(resp_body) => println!(
+            "Got validated response with status {} and body {}",
+            &response.status().as_str(),
+            &String::from_utf8(resp_body).unwrap()
+        ),
         Err(err) => println!("Error validating response: {:?}", err),
     }
 }


### PR DESCRIPTION
This PR gets validation of V1 responses working correctly. I have also made both of the version-specific validation functions private, with the new public `validate_response` function being the preferred API. It takes care of the logic of attempting the validate with V2, checking the flag for `allow_v1_response_auth` in the case of failures, and attempting to validate with V1 if the flag is set. The `sign_request` function is also the preferred interface for signing over the version-specific ones, but I will leave those publicly accessible for now, as they are able to maintain their original interface.