### PR TITLE
Document experimental status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 This crate allows users of the Hyper crate for making HTTP requests to sign those requests with
 the MAuth protocol, and verify the responses. Usage example:
 
+**Note**: This crate and Rust support within Medidata is considered experimental. Do not
+release any code to Production or deploy in a Client-accessible environment without getting
+approval for the full stack used through the Architecture and Security groups.
+
 ```rust
 let mauth_info = MAuthInfo::from_default_file().unwrap();
 let https = HttpsConnector::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
 //! This crate allows users of the Hyper crate for making HTTP requests to sign those requests with
 //! the MAuth protocol, and verify the responses. Usage example:
 //!
+//! **Note**: This crate and Rust support within Medidata is considered experimental. Do not
+//! release any code to Production or deploy in a Client-accessible environment without getting
+//! approval for the full stack used through the Architecture and Security groups.
+//!
 //! ```no_run
 //! # use mauth_client::MAuthInfo;
 //! # use hyper::{Body, Client, Method, Request, Response};


### PR DESCRIPTION
Add documentation stating that the Rust stack is to be considered experimental within Medidata, and no code using it should be released to Production without being validated through the required departments as a new code stack to be properly supported.