### PR TITLE
Set edition to 2021 and run clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mauth-client"
 version = "0.1.0"
 authors = ["Mason Gup <mgup@mdsol.com>"]
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/mauth-client/0.1.0/mauth_client/"
 license = "MIT"
 description = "Sign requests and validate responses using the Medidata MAuth protocol"


### PR DESCRIPTION
I was curious. Changes:
- change edition to 2021
- run `cargo update` 
- run `cargo clippy` and do the fixes 
- run `cargo build` and `cargo test`

Everything seems fine. @masongup-mdsol 