### PR TITLE
Tower validation service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,12 @@ openssl = ">= 0.10.0"
 regex = { version = "1", default_features = false, features = ["std"] }
 bytes = ">= 1.0.0"
 http = ">= 0.2.3"
-tower = ">= 0.4.13"
-futures-core = ">= 0.3.25"
+tower = { version = ">= 0.4.13", optional = true }
+futures-core = { version = ">= 0.3.25", optional = true }
+thiserror = ">= 1.0.37"
 
 [dev-dependencies]
 tokio = { version = ">= 1.0.1", features = ["rt-multi-thread", "macros"] }
+
+[features]
+server = ["tower", "futures-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ thiserror = ">= 1.0.37"
 tokio = { version = ">= 1.0.1", features = ["rt-multi-thread", "macros"] }
 
 [features]
-server = ["tower", "futures-core"]
+tower-service = ["tower", "futures-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ regex = { version = "1", default_features = false, features = ["std"] }
 bytes = ">= 1.0.0"
 http = ">= 0.2.3"
 tower = ">= 0.4.13"
+futures-core = ">= 0.3.25"
+lazy_static = ">= 1.4.0"
 
 [dev-dependencies]
 tokio = { version = ">= 1.0.1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mauth-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mason Gup <mgup@mdsol.com>"]
 edition = "2021"
-documentation = "https://docs.rs/mauth-client/0.1.0/mauth_client/"
+documentation = "https://docs.rs/mauth-client/"
 license = "MIT"
 description = "Sign requests and validate responses using the Medidata MAuth protocol"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ openssl = ">= 0.10.0"
 regex = { version = "1", default_features = false, features = ["std"] }
 bytes = ">= 1.0.0"
 http = ">= 0.2.3"
+tower = ">= 0.4.13"
 
 [dev-dependencies]
 tokio = { version = ">= 1.0.1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bytes = ">= 1.0.0"
 http = ">= 0.2.3"
 tower = ">= 0.4.13"
 futures-core = ">= 0.3.25"
-lazy_static = ">= 1.4.0"
 
 [dev-dependencies]
 tokio = { version = ">= 1.0.1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ hyper-tls = ">= 0.5.0"
 serde = { version = ">= 1.0.85", features = ["derive"] }
 serde_json = ">= 1.0.0"
 serde_yaml = ">= 0.8.0"
-uuid = { version = ">= 0.8.0", features = ["v4"] }
+uuid = { version = ">= 0.21.0", features = ["v4"] }
 dirs = ">= 2.0.0"
 base64 = ">= 0.10.0"
 chrono = ">= 0.4.0"

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ match client.request(req).await {
     }
 }
 ```
+
+The optional `tower-service` feature provides for a Tower Layer and Service that will
+authenticate incoming requests via MAuth V2 or V2 and provide to the lower layers a
+validated app_uuid from the request via the ValidatedRequestDetails struct.
+
+License: MIT

--- a/build.rs
+++ b/build.rs
@@ -44,5 +44,5 @@ async fn {formatted_name}_generate_headers() {{
             name = &name
         ));
     }
-    fs::write(&Path::new(&out_dir).join("protocol_tests.rs"), &code_str).unwrap();
+    fs::write(Path::new(&out_dir).join("protocol_tests.rs"), &code_str).unwrap();
 }

--- a/src/config_test.rs
+++ b/src/config_test.rs
@@ -13,7 +13,7 @@ async fn invalid_uri_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config);
+    let load_result = MAuthInfo::from_config_section(&bad_config, None);
     assert!(matches!(load_result, Err(ConfigReadError::InvalidUri(_))));
 }
 
@@ -27,7 +27,7 @@ async fn bad_file_path_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config);
+    let load_result = MAuthInfo::from_config_section(&bad_config, None);
     assert!(matches!(
         load_result,
         Err(ConfigReadError::FileReadError(_))
@@ -46,7 +46,7 @@ async fn bad_key_file_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config);
+    let load_result = MAuthInfo::from_config_section(&bad_config, None);
     fs::remove_file(&filename).await.unwrap();
     assert!(matches!(load_result, Err(ConfigReadError::OpenSSLError(_))));
 }
@@ -66,7 +66,7 @@ async fn bad_uuid_returns_right_error() {
         v2_only_sign_requests: None,
         v2_only_authenticate: None,
     };
-    let load_result = MAuthInfo::from_config_section(bad_config);
+    let load_result = MAuthInfo::from_config_section(&bad_config, None);
     fs::remove_file(&filename).await.unwrap();
     assert!(matches!(
         load_result,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl MAuthInfo {
         body_bytes: &bytes::Bytes,
     ) -> Result<Uuid, MAuthValidationError> {
         let mut hasher = Sha512::default();
-        hasher.update(&body_bytes);
+        hasher.update(body_bytes);
 
         //retrieve and parse auth string
         let sig_header = req
@@ -386,7 +386,7 @@ impl MAuthInfo {
         let mut hasher = Sha512::default();
         let string_to_sign1 = format!("{}\n{}\n", req.method(), req.uri().path());
         hasher.update(string_to_sign1.into_bytes());
-        hasher.update(&body_bytes);
+        hasher.update(body_bytes);
         let string_to_sign2 = format!("\n{}\n{}", &host_app_uuid, &ts_str);
         hasher.update(string_to_sign2.into_bytes());
         let sign_input: Vec<u8> = hex::encode(hasher.finalize()).into_bytes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub struct BodyDigest {
 /// The custom struct makes it clearer that the request has passed and this is an authenticated
 /// app UUID and not some random UUID that some other component put in place for some other
 /// purpose.
-#[cfg(feature = "server")]
+#[cfg(feature = "tower-service")]
 #[derive(Debug, Clone)]
 pub struct ValidatedRequestDetails {
     pub app_uuid: Uuid,
@@ -243,7 +243,7 @@ impl MAuthInfo {
         }
     }
 
-    #[cfg(feature = "server")]
+    #[cfg(feature = "tower-service")]
     async fn validate_request(
         &self,
         mut req: Request<Body>,
@@ -293,7 +293,7 @@ impl MAuthInfo {
         self.set_headers_v2(req, signature, &timestamp_str);
     }
 
-    #[cfg(feature = "server")]
+    #[cfg(feature = "tower-service")]
     async fn validate_request_v2(
         &self,
         req: &Request<Body>,
@@ -348,7 +348,7 @@ impl MAuthInfo {
         }
     }
 
-    #[cfg(feature = "server")]
+    #[cfg(feature = "tower-service")]
     async fn validate_request_v1(
         &self,
         req: &Request<Body>,
@@ -781,5 +781,5 @@ pub enum MAuthValidationError {
     SignatureVerifyFailure,
 }
 
-#[cfg(feature = "server")]
+#[cfg(feature = "tower-service")]
 pub mod tower;

--- a/src/protocol_test_suite.rs
+++ b/src/protocol_test_suite.rs
@@ -38,7 +38,7 @@ async fn setup_mauth_info() -> (MAuthInfo, u64) {
         v2_only_authenticate: None,
     };
     (
-        MAuthInfo::from_config_section(mock_config_section).unwrap(),
+        MAuthInfo::from_config_section(&mock_config_section, None).unwrap(),
         sign_config.request_time,
     )
 }

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -33,7 +33,7 @@ where
     fn call(&mut self, request: Request<Body>) -> Self::Future {
         let mut cloned = self.clone();
         Box::pin(async move {
-            match cloned.mauth_info.validate_request_v2(request).await {
+            match cloned.mauth_info.validate_request(request).await {
                 Ok(valid_request) => match cloned.service.call(valid_request).await {
                     Ok(response) => Ok(response),
                     Err(err) => Err(err.into()),

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,3 +1,5 @@
+//! Structs and impls related to providing a Tower Service and Layer to verify incoming requests
+
 use futures_core::future::BoxFuture;
 use hyper::{body::Body, Request};
 use openssl::{pkey::Public, rsa::Rsa};
@@ -10,6 +12,9 @@ use uuid::Uuid;
 
 use crate::{ConfigFileSection, ConfigReadError, MAuthInfo};
 
+/// This is a Tower Service which validates that incoming requests have a valid
+/// MAuth signature. It only passes the request down to the next layer if the
+/// signature is valid, otherwise it returns an appropriate error to the caller.
 pub struct MAuthValidationService<S> {
     mauth_info: MAuthInfo,
     config_info: ConfigFileSection,
@@ -59,6 +64,8 @@ impl<S: Clone> Clone for MAuthValidationService<S> {
     }
 }
 
+/// This is a Tower Layer which applies the MAuthValidationService on top of the
+/// service provided to it.
 #[derive(Clone)]
 pub struct MAuthValidationLayer {
     config_info: ConfigFileSection,
@@ -83,11 +90,24 @@ impl<S> Layer<S> for MAuthValidationLayer {
 }
 
 impl MAuthValidationLayer {
+    /// Construct a MAuthValidationLayer based on the configuration options in the file
+    /// found in the default location.
     pub fn from_default_file() -> Result<Self, ConfigReadError> {
         let config_info = MAuthInfo::config_section_from_default_file()?;
         let remote_key_store = Arc::new(RwLock::new(HashMap::new()));
         // Generate a MAuthInfo and then drop it to validate that it works,
         // making it safe to use `unwrap` in the service constructor.
+        MAuthInfo::from_config_section(&config_info, Some(remote_key_store.clone()))?;
+        Ok(MAuthValidationLayer {
+            config_info,
+            remote_key_store,
+        })
+    }
+
+    /// Construct a MAuthValidationLayer based on the configuration options in a manually
+    /// created or parsed ConfigFileSection.
+    pub fn from_config_section(config_info: ConfigFileSection) -> Result<Self, ConfigReadError> {
+        let remote_key_store = Arc::new(RwLock::new(HashMap::new()));
         MAuthInfo::from_config_section(&config_info, Some(remote_key_store.clone()))?;
         Ok(MAuthValidationLayer {
             config_info,

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,0 +1,97 @@
+use futures_core::future::BoxFuture;
+use hyper::{body::{to_bytes, HttpBody}, Request};
+use openssl::{pkey::Public, rsa::Rsa};
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::{Arc, RwLock};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+use uuid::Uuid;
+
+use crate::{ConfigFileSection, ConfigReadError, MAuthInfo};
+
+pub struct MAuthValidationService<S> {
+    mauth_info: MAuthInfo,
+    config_info: ConfigFileSection,
+    service: S,
+}
+
+impl<S, B> Service<Request<B>> for MAuthValidationService<S>
+where
+    S: Service<Request<B>> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<Box<dyn Error + Sync + Send>>,
+    B: HttpBody<Data = bytes::Bytes> + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Box<dyn Error + Sync + Send>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx).map_err(|e| e.into())
+    }
+
+    fn call(&mut self, request: Request<B>) -> Self::Future {
+        let mut cloned = self.clone();
+        Box::pin(async move {
+            match cloned.mauth_info.validate_request_v2(request).await {
+                Ok(valid_request) => match cloned.service.call(valid_request).await {
+                    Ok(response) => Ok(response),
+                    Err(err) => Err(err.into()),
+                },
+                Err(err) => Err(Box::new(err) as Box<dyn Error + Send + Sync>),
+            }
+        })
+    }
+}
+
+impl<S: Clone> Clone for MAuthValidationService<S> {
+    fn clone(&self) -> Self {
+        MAuthValidationService {
+            // unwrap is safe because we validated the config_info before constructing the layer
+            mauth_info: MAuthInfo::from_config_section(
+                &self.config_info,
+                Some(self.mauth_info.remote_key_store.clone()),
+            )
+            .unwrap(),
+            config_info: self.config_info.clone(),
+            service: self.service.clone(),
+        }
+    }
+}
+
+pub struct MAuthValidationLayer {
+    config_info: ConfigFileSection,
+    remote_key_store: Arc<RwLock<HashMap<Uuid, Rsa<Public>>>>,
+}
+
+impl<S> Layer<S> for MAuthValidationLayer {
+    type Service = MAuthValidationService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        MAuthValidationService {
+            // unwrap is safe because we validated the config_info before constructing the layer
+            mauth_info: MAuthInfo::from_config_section(
+                &self.config_info,
+                Some(self.remote_key_store.clone()),
+            )
+            .unwrap(),
+            config_info: self.config_info.clone(),
+            service,
+        }
+    }
+}
+
+impl MAuthValidationLayer {
+    pub fn from_default_file() -> Result<Self, ConfigReadError> {
+        let config_info = MAuthInfo::config_section_from_default_file()?;
+        let remote_key_store = Arc::new(RwLock::new(HashMap::new()));
+        // Generate a MAuthInfo and then drop it to validate that it works,
+        // making it safe to use `unwrap` in the service constructor.
+        MAuthInfo::from_config_section(&config_info, Some(remote_key_store.clone()))?;
+        Ok(MAuthValidationLayer {
+            config_info,
+            remote_key_store,
+        })
+    }
+}


### PR DESCRIPTION
With this update, the crate now supports validating incoming requests with both V2 and V1 using a Rust-standardized Tower Layer and Service. This integrates cleanly with the Axum web server as shown in [this quick example application](https://github.com/masongup-mdsol/test-server/blob/master/src/main.rs).