### PR TITLE
Needed to fix GHA deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,6 @@ jobs:
       - name: Run tests
         run: |
           cargo test --all-features
+          
+      - name: Publication Dry Run
+        run: cargo publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup Rust toolchain
       uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The GHA publish does not seem to work right without the Git submodules getting checked out