### PR TITLE
Optional signature middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mauth-client"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Mason Gup <mgup@mdsol.com>"]
 edition = "2021"
 documentation = "https://docs.rs/mauth-client/"
@@ -31,7 +31,7 @@ futures-core = { version = "0.3", optional = true }
 http = "1"
 bytes = { version = "1", optional = true }
 thiserror = "1"
-mauth-core = "0.5"
+mauth-core = "0.6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,17 +26,18 @@ dirs = "5"
 chrono = "0.4"
 tokio = { version = "1", features = ["fs"] }
 tower = { version = "0.4", optional = true }
-axum = { version = ">= 0.7.2", optional = true }
+axum = { version = ">= 0.8", optional = true }
 futures-core = { version = "0.3", optional = true }
 http = "1"
 bytes = { version = "1", optional = true }
 thiserror = "1"
 mauth-core = "0.6"
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [features]
-axum-service = ["tower", "futures-core", "axum", "bytes"]
+axum-service = ["tower", "futures-core", "axum", "bytes", "tracing"]
 tracing-otel-26 = ["reqwest-tracing/opentelemetry_0_26"]
 tracing-otel-27 = ["reqwest-tracing/opentelemetry_0_27"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ match client.get("https://www.example.com/").send().await {
 
 The optional `axum-service` feature provides for a Tower Layer and Service that will
 authenticate incoming requests via MAuth V2 or V1 and provide to the lower layers a
-validated app_uuid from the request via the ValidatedRequestDetails struct.
+validated app_uuid from the request via the ValidatedRequestDetails struct. Note that
+this feature now includes a `RequiredMAuthValidationLayer`, which will reject any
+requests without a valid signature before they reach lower layers, and also a
+`OptionalMAuthValidationLayer`, which lets all requests through, but only attaches a
+ValidatedRequestDetails extension struct if there is a valid signature. When using this
+layer, it is the responsiblity of the request handler to check for the extension and
+reject requests that are not properly authorized.
 
 There are also optional features `tracing-otel-26` and `tracing-otel-27` that pair with
 the `axum-service` feature to ensure that any outgoing requests for credentials that take

--- a/README.md
+++ b/README.md
@@ -51,13 +51,20 @@ match client.get("https://www.example.com/").send().await {
 
 The optional `axum-service` feature provides for a Tower Layer and Service that will
 authenticate incoming requests via MAuth V2 or V1 and provide to the lower layers a
-validated app_uuid from the request via the ValidatedRequestDetails struct. Note that
+validated app_uuid from the request via the `ValidatedRequestDetails` struct. Note that
 this feature now includes a `RequiredMAuthValidationLayer`, which will reject any
 requests without a valid signature before they reach lower layers, and also a
 `OptionalMAuthValidationLayer`, which lets all requests through, but only attaches a
-ValidatedRequestDetails extension struct if there is a valid signature. When using this
+`ValidatedRequestDetails` extension struct if there is a valid signature. When using this
 layer, it is the responsiblity of the request handler to check for the extension and
 reject requests that are not properly authorized.
+
+Note that `ValidatedRequestDetails` implements Axum's `FromRequestParts`, so you can
+specify it bare in a request handler. This implementation includes returning a 401
+Unauthorized status code if the extension is not present. If you would like to return
+a different response, or respond to the lack of the extension in another way, you can
+use a more manual mechanism to check for the extension and decide how to proceed if it
+is not present.
 
 There are also optional features `tracing-otel-26` and `tracing-otel-27` that pair with
 the `axum-service` feature to ensure that any outgoing requests for credentials that take

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ serve(listener, router).await.unwrap();
 # }
 ```
 
+### Error Handling
+
+Both the `RequiredMAuthValidationLayer` and the `OptionalMAuthValidationLayer` layers will
+log errors encountered via `tracing` under the `mauth_client::validate_incoming` target.
+
+The Required layer returns the 401 response immediately, so there is no convenient way to
+retrieve the error in order to do anything more sophisticated with it.
+
+The Optional layer, in addition to loging the error, will also add the `MAuthValidationError`
+to the request extensions. If desired, any request handlers or middlewares can retrieve it
+from there in order to take further actions based on the error type. This error type also
+implements Axum's `OptionalFromRequestParts`, so you can more easily retrieve it using
+`Option<MAuthValidationError>` anywhere that supports extractors.
+
 ### OpenTelemetry Integration
 
 There are also optional features `tracing-otel-26` and `tracing-otel-27` that pair with

--- a/src/axum_service.rs
+++ b/src/axum_service.rs
@@ -13,7 +13,7 @@ use std::task::{Context, Poll};
 use tower::{Layer, Service};
 use tracing::error;
 
-use crate::validate_incoming::ValidatedRequestDetails;
+use crate::validate_incoming::{MAuthValidationError, ValidatedRequestDetails};
 use crate::{
     config::{ConfigFileSection, ConfigReadError},
     MAuthInfo,
@@ -226,5 +226,19 @@ where
         _state: &S,
     ) -> Result<Option<Self>, Self::Rejection> {
         Ok(parts.extensions.get::<ValidatedRequestDetails>().cloned())
+    }
+}
+
+impl<S> OptionalFromRequestParts<S> for MAuthValidationError
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> Result<Option<Self>, Self::Rejection> {
+        Ok(parts.extensions.get::<MAuthValidationError>().cloned())
     }
 }

--- a/src/axum_service.rs
+++ b/src/axum_service.rs
@@ -14,13 +14,13 @@ use crate::{
 /// This is a Tower Service which validates that incoming requests have a valid
 /// MAuth signature. It only passes the request down to the next layer if the
 /// signature is valid, otherwise it returns an appropriate error to the caller.
-pub struct MAuthValidationService<S> {
+pub struct RequiredMAuthValidationService<S> {
     mauth_info: MAuthInfo,
     config_info: ConfigFileSection,
     service: S,
 }
 
-impl<S> Service<Request> for MAuthValidationService<S>
+impl<S> Service<Request> for RequiredMAuthValidationService<S>
 where
     S: Service<Request> + Send + Clone + 'static,
     S::Future: Send + 'static,
@@ -48,9 +48,9 @@ where
     }
 }
 
-impl<S: Clone> Clone for MAuthValidationService<S> {
+impl<S: Clone> Clone for RequiredMAuthValidationService<S> {
     fn clone(&self) -> Self {
-        MAuthValidationService {
+        RequiredMAuthValidationService {
             // unwrap is safe because we validated the config_info before constructing the layer
             mauth_info: MAuthInfo::from_config_section(&self.config_info).unwrap(),
             config_info: self.config_info.clone(),
@@ -59,18 +59,18 @@ impl<S: Clone> Clone for MAuthValidationService<S> {
     }
 }
 
-/// This is a Tower Layer which applies the MAuthValidationService on top of the
+/// This is a Tower Layer which applies the RequiredMAuthValidationService on top of the
 /// service provided to it.
 #[derive(Clone)]
-pub struct MAuthValidationLayer {
+pub struct RequiredMAuthValidationLayer {
     config_info: ConfigFileSection,
 }
 
-impl<S> Layer<S> for MAuthValidationLayer {
-    type Service = MAuthValidationService<S>;
+impl<S> Layer<S> for RequiredMAuthValidationLayer {
+    type Service = RequiredMAuthValidationService<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        MAuthValidationService {
+        RequiredMAuthValidationService {
             // unwrap is safe because we validated the config_info before constructing the layer
             mauth_info: MAuthInfo::from_config_section(&self.config_info).unwrap(),
             config_info: self.config_info.clone(),
@@ -79,21 +79,113 @@ impl<S> Layer<S> for MAuthValidationLayer {
     }
 }
 
-impl MAuthValidationLayer {
-    /// Construct a MAuthValidationLayer based on the configuration options in the file
+impl RequiredMAuthValidationLayer {
+    /// Construct a RequiredMAuthValidationLayer based on the configuration options in the file
     /// found in the default location.
     pub fn from_default_file() -> Result<Self, ConfigReadError> {
         let config_info = MAuthInfo::config_section_from_default_file()?;
         // Generate a MAuthInfo and then drop it to validate that it works,
         // making it safe to use `unwrap` in the service constructor.
         MAuthInfo::from_config_section(&config_info)?;
-        Ok(MAuthValidationLayer { config_info })
+        Ok(RequiredMAuthValidationLayer { config_info })
     }
 
-    /// Construct a MAuthValidationLayer based on the configuration options in a manually
+    /// Construct a RequiredMAuthValidationLayer based on the configuration options in a manually
     /// created or parsed ConfigFileSection.
     pub fn from_config_section(config_info: ConfigFileSection) -> Result<Self, ConfigReadError> {
         MAuthInfo::from_config_section(&config_info)?;
-        Ok(MAuthValidationLayer { config_info })
+        Ok(RequiredMAuthValidationLayer { config_info })
+    }
+}
+
+/// This is a Tower Service which validates that incoming requests have a valid
+/// MAuth signature. Unlike the Required service, if this service is not able to
+/// find or validate a signature, it passes the request down to the lower layers
+/// anyways. This means that it is the responsibility of the request handler to
+/// check for the `ValidatedRequestDetails` extension to determine if the request
+/// has a valid signature. It also means that this service is safe to attach to
+/// the whole application, even if some requests are not validated at all or may
+/// be validated in a different way.
+pub struct OptionalMAuthValidationService<S> {
+    mauth_info: MAuthInfo,
+    config_info: ConfigFileSection,
+    service: S,
+}
+
+impl<S> Service<Request> for OptionalMAuthValidationService<S>
+where
+    S: Service<Request> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<Box<dyn Error + Sync + Send>>,
+{
+    type Response = S::Response;
+    type Error = Box<dyn Error + Sync + Send>;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx).map_err(|e| e.into())
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let mut cloned = self.clone();
+        Box::pin(async move {
+            match cloned.mauth_info.validate_request_optionally(request).await {
+                Ok(valid_request) => match cloned.service.call(valid_request).await {
+                    Ok(response) => Ok(response),
+                    Err(err) => Err(err.into()),
+                },
+                Err(err) => Err(Box::new(err) as Box<dyn Error + Send + Sync>),
+            }
+        })
+    }
+}
+
+impl<S: Clone> Clone for OptionalMAuthValidationService<S> {
+    fn clone(&self) -> Self {
+        OptionalMAuthValidationService {
+            // unwrap is safe because we validated the config_info before constructing the layer
+            mauth_info: MAuthInfo::from_config_section(&self.config_info).unwrap(),
+            config_info: self.config_info.clone(),
+            service: self.service.clone(),
+        }
+    }
+}
+
+/// This is a Tower Layer which applies the OptionalMAuthValidationService on top of the
+/// service provided to it.
+#[derive(Clone)]
+pub struct OptionalMAuthValidationLayer {
+    config_info: ConfigFileSection,
+}
+
+impl<S> Layer<S> for OptionalMAuthValidationLayer {
+    type Service = OptionalMAuthValidationService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OptionalMAuthValidationService {
+            // unwrap is safe because we validated the config_info before constructing the layer
+            mauth_info: MAuthInfo::from_config_section(&self.config_info).unwrap(),
+            config_info: self.config_info.clone(),
+            service,
+        }
+    }
+}
+
+impl OptionalMAuthValidationLayer {
+    /// Construct an OptionalMAuthValidationLayer based on the configuration options in the file
+    /// found in the default location.
+    pub fn from_default_file() -> Result<Self, ConfigReadError> {
+        let config_info = MAuthInfo::config_section_from_default_file()?;
+        // Generate a MAuthInfo and then drop it to validate that it works,
+        // making it safe to use `unwrap` in the service constructor.
+        MAuthInfo::from_config_section(&config_info)?;
+        Ok(OptionalMAuthValidationLayer { config_info })
+    }
+
+    /// Construct an OptionalMAuthValidationLayer based on the configuration options in a manually
+    /// created or parsed ConfigFileSection.
+    pub fn from_config_section(config_info: ConfigFileSection) -> Result<Self, ConfigReadError> {
+        MAuthInfo::from_config_section(&config_info)?;
+        Ok(OptionalMAuthValidationLayer { config_info })
     }
 }

--- a/src/reqwest_middleware.rs
+++ b/src/reqwest_middleware.rs
@@ -6,7 +6,6 @@ use crate::{sign_outgoing::SigningError, MAuthInfo};
 
 #[async_trait::async_trait]
 impl Middleware for MAuthInfo {
-    #[must_use]
     async fn handle(
         &self,
         mut req: Request,

--- a/src/validate_incoming.rs
+++ b/src/validate_incoming.rs
@@ -107,8 +107,7 @@ impl MAuthInfo {
             }
 
             let new_body = axum::body::Body::from(body_bytes);
-            let new_request = Request::from_parts(parts, new_body);
-            new_request
+            Request::from_parts(parts, new_body)
         } else {
             Request::from_parts(parts, body)
         }


### PR DESCRIPTION
This PR redoes the middleware system. The previous code had one middleware which always rejected the request entirely if it could not find or validate a MAuth signature, not allowing it to reach the lower layers at all. This may be desirable in some cases, and is possible to use reasonably flexibly with the way most server routers support dynamically attaching layers to only some of the routes. After some work with it though, I decided that it is not sufficiently flexible for many reasonable uses. So here, I renamed the old layer and service to be `RequiredMAuthValidationLayer` and created a new one named `OptionalMAuthValidationLayer`. I also decided that a configuration option for this was insufficiently clear as to the intent of the user. This is a breaking change for any users of the old layer, but I don't think there are any right now, aside from the demo service I deployed. Making this not a breaking change would also require a default setting for the original layer, which in my opinion is insufficiently clear to users and readers of code using it regarding which mode the layer is operating in.

The Optional layer will attempt to check for a mauth signature, attach an extension to the request if it finds a valid one. However, it will always forward the request down the layers, whether or not it finds a valid signature. If this is used, it is the responsibility of the handler to specify that the extension is required, or use some other algorithm to validate requests.

To make this smoother, the `ValidatedRequestDetails` now also impls Axum's `FromRequestParts`, so you can include it in a handler function, and it will validate that it is present, make it available to the function if desired, and also return a 401 Unauthorized response if it is not present. The return code and body of the default Axum Extension extractor is not very good for this use case.

Also updated to use Yohei's updated mauth-core.